### PR TITLE
Fixing the icon problem

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     
     <!--Import Google Icon Font-->
-    <link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <!--Import materialize.css-->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.98.2/css/materialize.min.css">
 


### PR DESCRIPTION
Use https://fonts.googleapis.com/icon?family=Material+Icons instead of http://fonts.googleapis.com/icon?family=Material+Icons.
Use https Since, github uses secure links.